### PR TITLE
Fix issue #1: Add logging output

### DIFF
--- a/metadata/src/crawler.py
+++ b/metadata/src/crawler.py
@@ -148,7 +148,6 @@ def worker(raw_image: str, index: int, num_images: int) -> list:
                 result["full_description"] = result["description"]
             result["updated"] = content["last_updated"]
             result["pull_count"] = content["pull_count"]
-
             break
         except:
             if retry == max_retries:
@@ -215,6 +214,7 @@ def fetch_tags(namespace, image, index, num_images):
             content = utils.get_url_with_proxy(url)
             for result in content["results"]:
                 tags.append(result["name"])
+            logger.info(f"[{index + 1}/{num_images}] {namespace}/{image} has {len(tags)} tags now")
             if len(tags) >= 100:
                 logger.info(
                     f"[{index + 1}/{num_images}] {namespace}/{image} has tags more than 100, turncate."
@@ -248,6 +248,7 @@ def fetch_images_by_tag(namespace, image, tag, index, image_nums):
     max_retries, retry = 5, 0
     while retry < max_retries:
         try:
+            logger.info(f"[{index}/{image_nums}] {namespace}/{image}:{tag} is ready to fetch")
             content = utils.get_url_with_proxy(url)
             result = list()
             for image_obj in content:

--- a/metadata/src/utils.py
+++ b/metadata/src/utils.py
@@ -54,6 +54,7 @@ def request_proxy() -> str:
     """
     proxy = proxy_pool.proxy
     proxy_pool.life_span_count -= 1
+    logger.info(f"Proxy {proxy} now has {proxy_pool.life_span_count} lifetime left.")
     if proxy_pool.life_span_count <= 0:
         # The proxy has been expired
         logger.warning(f"[Connection] Proxy {proxy} has expired; ready to re-fetch")


### PR DESCRIPTION
```
[INFO] 2024-03-29 21:35:55 Got proxy 43.159.28.58:19358 with lifespan 5
[INFO] 2024-03-29 21:35:56 [112/872454] balenalib/bananapi-m1-plus-debian-python:3.10.10-buster-build-20240227 is ready to fetch
[INFO] 2024-03-29 21:35:56 Proxy 43.159.28.58:19358 now has 4 lifetime left.
[INFO] 2024-03-29 21:35:56 [112/872454] balenalib/bananapi-m1-plus-debian-python:3.10.10-latest-build is ready to fetch
[INFO] 2024-03-29 21:35:56 Proxy 43.159.28.58:19358 now has 3 lifetime left.
[INFO] 2024-03-29 21:35:57 [112/872454] balenalib/bananapi-m1-plus-debian-python:3.7.16-buster-build is ready to fetch
[INFO] 2024-03-29 21:35:57 Proxy 43.159.28.58:19358 now has 2 lifetime left.
[INFO] 2024-03-29 21:35:58 [112/872454] balenalib/bananapi-m1-plus-debian-python:3.10.10-latest-build-20240227 is ready to fetch
[INFO] 2024-03-29 21:35:58 Proxy 43.159.28.58:19358 now has 1 lifetime left.
[INFO] 2024-03-29 21:35:59 [112/872454] balenalib/bananapi-m1-plus-debian-python:3.7.16-bookworm-build-20240227 is ready to fetch
[INFO] 2024-03-29 21:35:59 Proxy 43.159.28.58:19358 now has 0 lifetime left.
[WARNING] 2024-03-29 21:35:59 [Connection] Proxy 43.159.28.58:19358 has expired; ready to re-fetch
[INFO] 2024-03-29 21:35:59 Proxy 43.159.28.58:19358 is expired. Fetching a new one
[INFO] 2024-03-29 21:35:59 Got proxy 43.159.30.199:19108 with lifespan 5
```